### PR TITLE
Fail if the PR cannot be merged

### DIFF
--- a/prepare-commit
+++ b/prepare-commit
@@ -121,9 +121,14 @@ fi
 read -p "  commit message [$MSG]: " INPUT
 [ -n "$INPUT" ] && MSG=$INPUT
 
+
 # merge the contributor's branch and commit
-git merge --squash "$PR_BRANCH"; then
-git commit --author="$AUTHOR" -a -m "$MSG"
+echo ""
+if git merge --squash "$PR_BRANCH"; then
+  git commit --author="$AUTHOR" -a -m "$MSG"
+else
+  exit $?
+fi
 
 # review the commit
 echo ""


### PR DESCRIPTION
If the PR cannot be merged due to a conflict, the script will now explicitly fail.