### PR TITLE
Add support for apache/metron-bro-plugin-kafka

### DIFF
--- a/checkout-pr
+++ b/checkout-pr
@@ -1,4 +1,4 @@
-#/usr/local/bin bash
+#!/usr/bin/env bash
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +16,11 @@
 #  limitations under the License.
 #
 
-ORIGIN="http://github.com/apache/metron"
+# Standard instantiations
+METRON_ORIGIN="https://github.com/apache/metron"
+METRON_ORIGIN_no_proto="${METRON_ORIGIN#*://}"
+BRO_PLUGIN_ORIGIN="https://github.com/apache/metron-bro-plugin-kafka"
+BRO_PLUGIN_ORIGIN_no_proto="${BRO_PLUGIN_ORIGIN#*://}"
 
 if [ "$#" -ne 1 ]; then
     echo "error: missing argument"
@@ -26,14 +30,60 @@ else
     PR_NUMBER="$1"
 fi
 
+# which repo?  metron or metron-bro-plugin-kafka
+read -p "  which repo? [metron]: " INPUT
+case "${INPUT}" in
+  [Bb][Rr][Oo]|[Mm][Ee][Tt][Rr][Oo][Nn]-[Bb][Rr][Oo]-[Pp][Ll][Uu][Gg][Ii][Nn]-[Kk][Aa][Ff][Kk][Aa]|*metron-bro-plugin-kafka\.git)
+    SELECTED_ORIGIN="${BRO_PLUGIN_ORIGIN}"
+    SELECTED_ORIGIN_no_proto="${SELECTED_ORIGIN#*://}";;
+  [Mm][Ee][Tt][Rr][Oo][Nn]|*metron\.git|'')
+    SELECTED_ORIGIN="${METRON_ORIGIN}"
+    SELECTED_ORIGIN_no_proto="${SELECTED_ORIGIN#*://}";;
+  *)
+    echo "Invalid repo, provided \"${INPUT}\".  Please choose between metron or metron-bro-plugin-kafka"
+    exit 1
+    ;;
+esac
 
-# if we do not already have a cloned repo, create it
-CURR_ORIGIN=`git remote -v | grep origin | head -1 | awk '{print $2}'`
-if [ "$ORIGIN" != "$CURR_ORIGIN" ]; then
-  git clone $ORIGIN metron-pr-$PR_NUMBER
-  cd metron-pr-$PR_NUMBER
+# Check the origin of the current directory
+CURR_ORIGIN=`git remote -v 2>/dev/null | grep origin | head -1 | awk '{print $2}'`
+CURR_ORIGIN_no_proto="${CURR_ORIGIN#*://}"
+
+# Warn if in a metron-related repo, but not the expected one
+if [[ "${CURR_ORIGIN_no_proto}" == "${METRON_ORIGIN_no_proto}" && "${SELECTED_ORIGIN}" == "${BRO_PLUGIN_ORIGIN}" ]]; then
+  read -p "  WARN:  You are in a metron repo but checking out a metron-bro-plugin-kafka pr.  Continue? [yN] " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
+elif [[ "${CURR_ORIGIN_no_proto}" == "${BRO_PLUGIN_ORIGIN_no_proto}" && "${SELECTED_ORIGIN}" == "${METRON_ORIGIN}" ]]; then
+  read -p "  WARN:  You are in a metron-bro-plugin-kafka repo but checking out a metron pr.  Continue? [yN] " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
+fi
+
+# If we're not in the same repo that we want to work with, clone it appropriately
+if [[ "${SELECTED_ORIGIN_no_proto}" != "${CURR_ORIGIN_no_proto}"  ]]; then
+  if [[ "${SELECTED_ORIGIN_no_proto}" == "${METRON_ORIGIN_no_proto}" ]]; then
+    git clone $METRON_ORIGIN metron-pr$PR_NUMBER
+    cd metron-pr$PR_NUMBER
+  elif [[ "${SELECTED_ORIGIN_no_proto}" == "${BRO_PLUGIN_ORIGIN_no_proto}" ]]; then
+    git clone $BRO_PLUGIN_ORIGIN metron-bro-plugin-kafka-pr$PR_NUMBER
+    cd metron-bro-plugin-kafka-pr$PR_NUMBER
+  fi
+fi
+
+# Warn that folder naming could get confusing
+if [[ ( "${SELECTED_ORIGIN##*/}" == "${METRON_ORIGIN##*/}" && "${PWD##*/}" != "metron-pr$PR_NUMBER" && "${PWD##*/}" =~ metron-pr[0-9]+ ) || ( "${SELECTED_ORIGIN##*/}" == "${BRO_PLUGIN_ORIGIN##*/}" && "${PWD##*/}" != "metron-bro-plugin-kafka-pr$PR_NUMBER" && "${PWD##*/}" =~ metron-bro-plugin-kafka-pr[0-9]+ ) ]]; then
+  echo "  WARN:  You are checking out a PR which is different than the PR in your current working directory.  Things could get confusing."
+  read -p "  WARN:  This will merge PR ${PR_NUMBER} into the folder ${PWD##*/}.  Continue? [yN] " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then exit 1; fi
 fi
 
 # fetch the PR and switch to it
-git fetch origin pull/$PR_NUMBER/head:pr-$PR_NUMBER
+if [[ "${SELECTED_ORIGIN_no_proto}" == "${METRON_ORIGIN_no_proto}" ]]; then
+  git fetch ${METRON_ORIGIN} pull/$PR_NUMBER/head:pr-$PR_NUMBER
+elif [[ "${SELECTED_ORIGIN_no_proto}" == "${BRO_PLUGIN_ORIGIN_no_proto}" ]]; then
+  git fetch ${BRO_PLUGIN_ORIGIN} pull/$PR_NUMBER/head:pr-$PR_NUMBER
+fi
 git checkout pr-$PR_NUMBER
+

--- a/checkout-pr
+++ b/checkout-pr
@@ -31,7 +31,9 @@ else
 fi
 
 # which repo?  metron or metron-bro-plugin-kafka
-read -p "  which repo? [metron]: " INPUT
+echo "  1) metron"
+echo "  2) metron-bro-plugin-kafka"
+read -p "Please select a repository [metron]: " INPUT
 case "${INPUT}" in
   [Bb][Rr][Oo]|[Mm][Ee][Tt][Rr][Oo][Nn]-[Bb][Rr][Oo]-[Pp][Ll][Uu][Gg][Ii][Nn]-[Kk][Aa][Ff][Kk][Aa]|*metron-bro-plugin-kafka\.git)
     SELECTED_ORIGIN="${BRO_PLUGIN_ORIGIN}"

--- a/checkout-pr
+++ b/checkout-pr
@@ -31,14 +31,15 @@ else
 fi
 
 # which repo?  metron or metron-bro-plugin-kafka
+echo "Please select a repository:"
 echo "  1) metron"
 echo "  2) metron-bro-plugin-kafka"
-read -p "Please select a repository [metron]: " INPUT
+read -p "Selection [metron]: " INPUT
 case "${INPUT}" in
-  [Bb][Rr][Oo]|[Mm][Ee][Tt][Rr][Oo][Nn]-[Bb][Rr][Oo]-[Pp][Ll][Uu][Gg][Ii][Nn]-[Kk][Aa][Ff][Kk][Aa]|*metron-bro-plugin-kafka\.git)
+  2|[Bb][Rr][Oo]|[Mm][Ee][Tt][Rr][Oo][Nn]-[Bb][Rr][Oo]-[Pp][Ll][Uu][Gg][Ii][Nn]-[Kk][Aa][Ff][Kk][Aa]|*metron-bro-plugin-kafka\.git)
     SELECTED_ORIGIN="${BRO_PLUGIN_ORIGIN}"
     SELECTED_ORIGIN_no_proto="${SELECTED_ORIGIN#*://}";;
-  [Mm][Ee][Tt][Rr][Oo][Nn]|*metron\.git|'')
+  1|[Mm][Ee][Tt][Rr][Oo][Nn]|*metron\.git|'')
     SELECTED_ORIGIN="${METRON_ORIGIN}"
     SELECTED_ORIGIN_no_proto="${SELECTED_ORIGIN#*://}";;
   *)

--- a/prepare-commit
+++ b/prepare-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -16,7 +17,8 @@
 #
 
 # not likely to change
-UPSTREAM=https://git-wip-us.apache.org/repos/asf/metron.git
+METRON_UPSTREAM="https://git-wip-us.apache.org/repos/asf/metron.git"
+BRO_PLUGIN_UPSTREAM="https://git-wip-us.apache.org/repos/asf/metron-bro-plugin-kafka.git"
 BASE_BRANCH=master
 CONFIG_FILE=~/.metron-prepare-commit
 
@@ -25,6 +27,22 @@ if [ -f $CONFIG_FILE ]; then
   . $CONFIG_FILE
   echo "  ...using settings from $CONFIG_FILE"
 fi
+
+# which repo?  metron or metron-bro-plugin-kafka
+read -p "  which repo? [metron]: " INPUT
+case "${INPUT}" in
+  [Bb][Rr][Oo]|[Mm][Ee][Tt][Rr][Oo][Nn]-[Bb][Rr][Oo]-[Pp][Ll][Uu][Gg][Ii][Nn]-[Kk][Aa][Ff][Kk][Aa]|*metron-bro-plugin-kafka\.git)
+    INPUT="${BRO_PLUGIN_UPSTREAM}" ;;
+  [Mm][Ee][Tt][Rr][Oo][Nn]|*metron\.git|'')
+    INPUT="${METRON_UPSTREAM}" ;;
+  *)
+    echo "Invalid repo, provided \"${INPUT}\".  Please choose between metron or metron-bro-plugin-kafka"
+    exit 1
+    ;;
+esac
+[ -n "$INPUT" ] && UPSTREAM=$INPUT
+
+CHOSEN_REPO=$(basename ${UPSTREAM%%.git})
 
 # github account of committer (you)
 if [ -z "$GITHUB_NAME" ]; then
@@ -62,19 +80,19 @@ if [ -z "$PR" ]; then
 fi
 
 # ensure that the pull request exists
-PR_EXISTS=`curl -sI https://api.github.com/repos/apache/metron/pulls/$PR | grep Status: | sed 's/[^0-9]//g'`
+PR_EXISTS=`curl -sI https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/$PR | grep Status: | sed 's/[^0-9]//g'`
 if [ "$PR_EXISTS" != "200" ]; then
   echo "Error: pull request #$PR does not exist"
   exit 1
 fi
 
 # origin repository
-ORIGIN="https://github.com/apache/metron"
+ORIGIN="https://github.com/apache/${CHOSEN_REPO}"
 read -p "  origin repo [$ORIGIN]: " INPUT
 [ -n "$INPUT" ] && ORIGIN=$INPUT
 
 # working directory
-WORK=~/tmp/metron-pr$PR
+WORK=~/tmp/${CHOSEN_REPO}-pr$PR
 read -p "  local working directory [$WORK]: " INPUT
 [ -n "$INPUT" ] && WORK=$INPUT
 
@@ -118,7 +136,7 @@ git fetch origin $PR_BRANCH_REF
 echo ""
 
 # use github api to retrieve the contributor's login
-USER=`curl -s https://api.github.com/repos/apache/metron/pulls/$PR | grep login | head -1 | awk -F":" '{print $2}' | sed 's/[^a-zA-Z.@_-]//g'`
+USER=`curl -s https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/$PR | grep login | head -1 | awk -F":" '{print $2}' | sed 's/[^a-zA-Z.@_-]//g'`
 read -p "  github contributor's username [$USER]: " INPUT
 [ -n "$INPUT" ] && USER=$INPUT
 
@@ -140,7 +158,7 @@ if [ -z "$EMAIL" ] || [ "$EMAIL" = "null" ]; then
 fi
 
 # can we extract the JIRA from the PR title?
-JIRA=`curl -s https://api.github.com/repos/apache/metron/pulls/$PR | grep title | head -1 | egrep -o -i 'METRON-[0-9]+' | awk '{print toupper($0)}'`
+JIRA=`curl -s https://api.github.com/repos/apache/${CHOSEN_REPO}/pulls/$PR | grep title | head -1 | egrep -o -i 'METRON-[0-9]+' | awk '{print toupper($0)}'`
 read -p "  issue identifier in jira [$JIRA]: " INPUT
 [ -n "$INPUT" ] && JIRA=$INPUT
 
@@ -164,9 +182,9 @@ fi
 # commit message
 AUTHOR="$USER <$EMAIL>"
 if [ "$USER" == "$GITHUB_NAME" ]; then
-    MSG="$JIRA $DESC ($USER) closes apache/metron#$PR"
+  MSG="$JIRA $DESC ($USER) closes apache/${CHOSEN_REPO}#$PR"
 else
-    MSG="$JIRA $DESC ($USER via $GITHUB_NAME) closes apache/metron#$PR"
+  MSG="$JIRA $DESC ($USER via $GITHUB_NAME) closes apache/${CHOSEN_REPO}#$PR"
 fi
 read -p "  commit message [$MSG]: " INPUT
 [ -n "$INPUT" ] && MSG=$INPUT
@@ -193,11 +211,15 @@ echo ""
 read -p "  run test suite? [yN] " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  mvn -q -T 2C -DskipTests clean install &&
-    mvn -q -T 2C surefire:test@unit-tests &&
-    mvn -q surefire:test@integration-tests &&
-    mvn -q test --projects metron-interface/metron-config &&
-    build_utils/verify_licenses.sh
+  if [ "${UPSTREAM}" == "${METRON_UPSTREAM}" ]; then
+    mvn -q -T 2C -DskipTests clean install &&
+        mvn -q -T 2C surefire:test@unit-tests &&
+        mvn -q surefire:test@integration-tests &&
+        mvn -q test --projects metron-interface/metron-config &&
+        build_utils/verify_licenses.sh
+  elif [ "${UPSTREAM}" == "${BRO_PLUGIN_UPSTREAM}" ]; then
+    echo "We don't currently support running metron-bro-plugin-kafka tests in this script"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
This is to add support for apache/metron-bro-plugin-kafka to both the `prepare-commit` and `checkout-pr` scripts.  It should default to apache/metron across the board, but allows you to specify metron-bro-plugin-kafka when prompted, which should propagate properly throughout the rest of the3 script.  This also adds some checks for various scenarios I thought up during my updates.